### PR TITLE
Initial implementation of "cone optimization" constraint.

### DIFF
--- a/src/corrgi/alignment.py
+++ b/src/corrgi/alignment.py
@@ -4,6 +4,11 @@ import pandas as pd
 from hipscat.catalog import Catalog
 from hipscat.pixel_tree.pixel_alignment import PixelAlignment
 from hipscat.pixel_tree.pixel_alignment_types import PixelAlignmentType
+import hipscat.pixel_math.healpix_shim as hp
+
+from corrgi.utils import project_coordinates
+import gundam.cflibfor as cff
+import numpy as np
 
 column_names = [
     PixelAlignment.PRIMARY_ORDER_COLUMN_NAME,
@@ -15,7 +20,7 @@ column_names = [
 ]
 
 
-def autocorrelation_alignment(catalog: Catalog) -> PixelAlignment:
+def autocorrelation_alignment(catalog: Catalog, bins=None) -> PixelAlignment:
     """Determine all pairs of partitions that should be correlated within the same catalog.
 
     This considers all combinations, without duplicates between the "primary" and "join"
@@ -27,12 +32,65 @@ def autocorrelation_alignment(catalog: Catalog) -> PixelAlignment:
     Returns:
         The alignment object where the `aligned` columns simply match the left pixel.
     """
-    upper_triangle = [
-        [left.order, left.pixel, right.order, right.pixel, left.order, left.pixel]
-        for (left, right) in itertools.combinations(catalog.get_healpix_pixels(), 2)
+    if bins is None or len(bins) == 0:
+        upper_triangle = [
+            [left.order, left.pixel, right.order, right.pixel, left.order, left.pixel]
+            for (left, right) in itertools.combinations(catalog.get_healpix_pixels(), 2)
+        ]
+        upper_triangle = pd.DataFrame(upper_triangle, columns=column_names)
+        return PixelAlignment(catalog.pixel_tree, upper_triangle, PixelAlignmentType.OUTER)
+
+    all_pixels = catalog.get_healpix_pixels()
+    num_partitions = len(all_pixels)
+    all_radec = [
+        hp.vec2dir(hp.boundaries(2**part.order, part.pixel, step=64, nest=True), lonlat=True)
+        for part in all_pixels
     ]
-    upper_triangle = pd.DataFrame(upper_triangle, columns=column_names)
-    return PixelAlignment(catalog.pixel_tree, upper_triangle, PixelAlignmentType.OUTER)
+    all_xyz = [project_coordinates(ra=bounds[0], dec=bounds[1]) for bounds in all_radec]
+
+    pix_a_order = []
+    pix_a_pixel = []
+    pix_b_order = []
+    pix_b_pixel = []
+    for a in range(0, num_partitions):
+        for b in range(a+1, num_partitions):
+            a_x, a_y, a_z = all_xyz[a]
+            b_x, b_y, b_z = all_xyz[b]
+            args = [
+                len(a_x),  # number of particles of the left partition
+                a_x,
+                a_y,
+                a_z,  # X,Y,Z coordinates of particles
+                len(b_x),  # number of particles of the right partition
+                b_x,
+                b_y,
+                b_z,  # X,Y,Z coordinates of particles
+                len(bins) - 1,  # number of angular separation bins
+                bins,  # bins in angular separation [deg]
+            ]
+            bins_populated = cff.mod.th_C_naiveway(*args)
+            populated_bins = np.flatnonzero(bins_populated)
+            if len(populated_bins) > 0:
+                pix_a_order.append(all_pixels[a].order)
+                pix_a_pixel.append(all_pixels[a].pixel)
+                pix_b_order.append(all_pixels[b].order)
+                pix_b_pixel.append(all_pixels[b].pixel)
+
+    if len(pix_a_order) == 0:
+        raise ValueError("no valid overlaps")
+
+    constrained_upper_triangle = pd.DataFrame(
+        {
+            PixelAlignment.PRIMARY_ORDER_COLUMN_NAME: pix_a_order,
+            PixelAlignment.PRIMARY_PIXEL_COLUMN_NAME: pix_a_pixel,
+            PixelAlignment.JOIN_ORDER_COLUMN_NAME: pix_b_order,
+            PixelAlignment.JOIN_PIXEL_COLUMN_NAME: pix_b_pixel,
+            PixelAlignment.ALIGNED_ORDER_COLUMN_NAME: pix_a_order,
+            PixelAlignment.ALIGNED_PIXEL_COLUMN_NAME: pix_a_pixel,
+        }
+    )
+
+    return PixelAlignment(catalog.pixel_tree, constrained_upper_triangle, PixelAlignmentType.OUTER)
 
 
 def crosscorrelation_alignment(catalog_left: Catalog, catalog_right: Catalog) -> PixelAlignment:

--- a/src/corrgi/dask.py
+++ b/src/corrgi/dask.py
@@ -23,7 +23,10 @@ def perform_auto_counts(catalog: Catalog, *args) -> np.ndarray:
         The histogram with the sample distance counts.
     """
     # Get counts between points of different partitions
-    alignment = autocorrelation_alignment(catalog.hc_structure)
+    bins = args[0].make_bins()
+    if len(bins) == 2:
+        bins = bins[0]
+    alignment = autocorrelation_alignment(catalog.hc_structure, bins)
     left_pixels, right_pixels = get_healpix_pixels_from_alignment(alignment)
     cross_partials = align_and_apply(
         [(catalog, left_pixels), (catalog, right_pixels)], count_cross_pairs, *args

--- a/tests/corrgi/test_alignment.py
+++ b/tests/corrgi/test_alignment.py
@@ -19,3 +19,9 @@ def test_crosscorrelation_alignment(dr7_lrg_catalog_dir, dr7_lrg_rand_catalog_di
     ## 12*21 = 252
     assert len(alignment.pixel_mapping) == 252
     assert len(alignment.pixel_mapping.columns) == 6
+
+def test_autocorrelation_alignment_constrained(data_catalog_dir, acf_corr_bins):
+    data_catalog = hipscat.read_from_hipscat(data_catalog_dir)
+    alignment = autocorrelation_alignment(data_catalog, acf_corr_bins)
+    assert len(alignment.pixel_mapping) == 14
+    assert len(alignment.pixel_mapping.columns) == 6


### PR DESCRIPTION
## Change Description

Simple implementation of the "cone optimization" constraint that drops partition pairs if we believe there will be no pair counts between any particles in the two partitions.

Only implemented for auto-correlation pair finding at first.